### PR TITLE
Using assignment instead of memset()

### DIFF
--- a/src/compile.cc
+++ b/src/compile.cc
@@ -289,7 +289,9 @@ int Compiler::AllocInst(int n) {
     if (inst_len_ > 0) {
       memmove(ip, inst_, inst_len_ * sizeof ip[0]);
     }
-    memset(ip + inst_len_, 0, (inst_cap_ - inst_len_) * sizeof ip[0]);
+
+    inst_len_ = {};
+
     delete[] inst_;
     inst_ = ip;
   }


### PR DESCRIPTION
I have examined the following CRAN checks at https://www.r-project.org/nosvn/R.check/r-release-linux-x86_64/re2r-00check.html and have seen that there are several warnings due to `memset()`
